### PR TITLE
Support cross namespace services

### DIFF
--- a/api/v1alpha1/service_types.go
+++ b/api/v1alpha1/service_types.go
@@ -33,6 +33,8 @@ type K8sPort struct {
 type K8sService struct {
 	// +kubebuilder:validation:Required
 	Name string `json:"name,omitempty"`
+	// +optional
+	Namespace string `json:"namespace,omitempty"`
 	// +kubebuilder:validation:Required
 	Port K8sPort `json:"port,omitempty"`
 }

--- a/helm/crds/api.kxds.dev_xdsservices.yaml
+++ b/helm/crds/api.kxds.dev_xdsservices.yaml
@@ -58,6 +58,8 @@ spec:
                             properties:
                               name:
                                 type: string
+                              namespace:
+                                type: string
                               port:
                                 description: K8sPort represents a reference to a port.
                                   This could be done either by number or by name.

--- a/kxds/xds.go
+++ b/kxds/xds.go
@@ -200,7 +200,7 @@ func makeCluster(clusterName string) *cluster.Cluster {
 	}
 }
 
-func makeLoadAssignment(clusterName, namespace string, localities []kxdsv1alpha1.Locality, k8sEndpoints map[ktypes.NamespacedName]corev1.Endpoints) (*endpoint.ClusterLoadAssignment, error) {
+func makeLoadAssignment(clusterName, currentNamespace string, localities []kxdsv1alpha1.Locality, k8sEndpoints map[ktypes.NamespacedName]corev1.Endpoints) (*endpoint.ClusterLoadAssignment, error) {
 	xdsLocalities := make([]*endpoint.LocalityLbEndpoints, len(localities))
 
 	for i, locSpec := range localities {
@@ -208,7 +208,13 @@ func makeLoadAssignment(clusterName, namespace string, localities []kxdsv1alpha1
 			return nil, errors.New("unsupported non k8s service locality")
 		}
 
-		k8sEndpoint, ok := k8sEndpoints[ktypes.NamespacedName{Namespace: namespace, Name: locSpec.Service.Name}]
+		targetNamespace := locSpec.Service.Namespace
+
+		if targetNamespace == "" {
+			targetNamespace = currentNamespace
+		}
+
+		k8sEndpoint, ok := k8sEndpoints[ktypes.NamespacedName{Namespace: targetNamespace, Name: locSpec.Service.Name}]
 		if !ok {
 			return nil, errors.New("no k8s endpoints found")
 		}


### PR DESCRIPTION
### What Does This PR do?

This PR adds a `namespace` attribute to a K8s Service ref. This allows to pick up an endpoint from another namespace.

### Good PR Checklist

- [ ] Addresses one issue
- [x] Adds/Updates unit tests
- [ ] Adds/Updates e2e tests
- [ ] Adds/Updates the documentation
- [ ] Opened against the right branch
- [ ] Correctly Labeled