### PR TITLE
Drop listener in spec

### DIFF
--- a/api/v1alpha1/service_types.go
+++ b/api/v1alpha1/service_types.go
@@ -199,9 +199,6 @@ type Route struct {
 
 // XDSServiceSpec defines the desired state of Service
 type XDSServiceSpec struct {
-	// Listener is the listener name that is used to identitfy a specific service from an xDS perspective.
-	// +kubebuilder:validation:Required
-	Listener string `json:"listener,omitempty"`
 	// MaxStreamDuration is the total duration to keep alive an HTTP request/response stream.
 	// If the time limit is reached the stream will be reset independent of any other timeouts.
 	// If not specified, this value is not set.

--- a/example/k8s/echo-server/1-grpc-service.yaml
+++ b/example/k8s/echo-server/1-grpc-service.yaml
@@ -2,14 +2,13 @@
 # https://github.com/grpc/proposal/blob/master/A27-xds-global-load-balancing.md
 ---
 # Basic example: one listeners maps to a route and a single K8s service
-# Listener address: xds://echo-server-basic
+# Listener address: xds:///echo-server/basic
 apiVersion: api.kxds.dev/v1alpha1
 kind: XDSService
 metadata:
-  name: basic-example
+  name: basic
   namespace: echo-server
 spec:
-  listener: echo-server-basic
   routes:
     - clusters:
         - name: default
@@ -23,14 +22,13 @@ spec:
 ---
 # Locality based Weighted Round Robin: This example makes all gRPC clients using this listener send 20% of their traffic to
 # the v2 instance of the echo-server, and 80% to the v1 instance.
-# Listener address: xds://echo-server-locality-wrr
+# Listener address: xds:///echo-server/locality-wrr
 apiVersion: api.kxds.dev/v1alpha1
 kind: XDSService
 metadata:
   name: locality-wrr
   namespace: echo-server
 spec:
-  listener: echo-server-locality-wrr
   routes:
     - clusters:
         - name: default
@@ -50,14 +48,13 @@ spec:
 ---
 # Locality fallback: This example makes all gRPC clients using this listener send 100% the the `echo-server-v2` service
 # but fall back to the v1 instance if the v2 service goes down.
-# Listener address: xds://echo-server-fallback
+# Listener address: xds:///echo-server/fallback
 apiVersion: api.kxds.dev/v1alpha1
 kind: XDSService
 metadata:
   name: fallback
   namespace: echo-server
 spec:
-  listener: echo-server-fallback
   routes:
     - clusters:
         - name: default
@@ -84,7 +81,6 @@ metadata:
   name: path-matcher
   namespace: echo-server
 spec:
-  listener: echo-server-path
   routes:
     - path:
         path: /echo.Echo/EchoPremium
@@ -113,7 +109,6 @@ metadata:
   name: prefix-matcher
   namespace: echo-server
 spec:
-  listener: echo-server-prefix
   routes:
     - path:
         prefix: /echo.Echo/EchoP
@@ -142,7 +137,6 @@ metadata:
   name: regex-matcher
   namespace: echo-server
 spec:
-  listener: echo-server-regex
   routes:
     - path:
         regex:
@@ -173,7 +167,6 @@ metadata:
   name: header-exact-matcher
   namespace: echo-server
 spec:
-  listener: echo-server-header-exact
   routes:
     - headers:
         - name: "x-version"
@@ -203,7 +196,6 @@ metadata:
   name: fractional-route-matcher
   namespace: echo-server
 spec:
-  listener: echo-server-fraction-route
   routes:
     - fraction:
         numerator: 20
@@ -232,7 +224,6 @@ metadata:
   name: circuit-breaker
   namespace: echo-server
 spec:
-  listener: echo-server-circuit-breaker
   routes:
     - clusters:
         - name: v1
@@ -253,7 +244,6 @@ metadata:
   name: delay-fault-injection
   namespace: echo-server
 spec:
-  listener: echo-server-delay-fixed-fault
   filters:
     - fault:
         delay:
@@ -278,7 +268,6 @@ metadata:
   name: fault-injection-header
   namespace: echo-server
 spec:
-  listener: echo-server-header-fault
   filters:
     - fault:
         abort:

--- a/helm/crds/api.kxds.dev_xdsservices.yaml
+++ b/helm/crds/api.kxds.dev_xdsservices.yaml
@@ -221,10 +221,6 @@ spec:
                       type: object
                   type: object
                 type: array
-              listener:
-                description: Listener is the listener name that is used to identitfy
-                  a specific service from an xDS perspective.
-                type: string
               maxStreamDuration:
                 description: MaxStreamDuration is the total duration to keep alive
                   an HTTP request/response stream. If the time limit is reached the

--- a/kxds/kxds_test.go
+++ b/kxds/kxds_test.go
@@ -100,7 +100,6 @@ func TestReconciller(t *testing.T) {
 				testruntime.BuildXDSService(
 					"test-xds",
 					"default",
-					"echo_server",
 					testruntime.WithRoutes(
 						testruntime.BuildSingleRoute("default"),
 					),
@@ -123,7 +122,7 @@ func TestReconciller(t *testing.T) {
 			},
 			backendsBehavior: answer,
 			doAssert: testruntime.CallOnce(
-				"xds:///echo_server",
+				"xds:///default/test-xds",
 				testruntime.BuildCaller(
 					testruntime.MethodEcho,
 				),
@@ -142,7 +141,6 @@ func TestReconciller(t *testing.T) {
 				testruntime.BuildXDSService(
 					"test-xds",
 					"default",
-					"echo_server",
 					testruntime.WithRoutes(
 						testruntime.BuildSingleRoute("default"),
 					),
@@ -167,7 +165,7 @@ func TestReconciller(t *testing.T) {
 			},
 			backendsBehavior: answer,
 			doAssert: testruntime.CallOnce(
-				"xds:///echo_server",
+				"xds:///default/test-xds",
 				testruntime.BuildCaller(
 					testruntime.MethodEcho,
 				),
@@ -186,7 +184,6 @@ func TestReconciller(t *testing.T) {
 				testruntime.BuildXDSService(
 					"test-xds",
 					"default",
-					"echo_server",
 					testruntime.WithRoutes(
 						testruntime.BuildSingleRoute("default"),
 					),
@@ -210,7 +207,7 @@ func TestReconciller(t *testing.T) {
 			},
 			backendsBehavior: answer,
 			doAssert: testruntime.CallOnce(
-				"xds:///echo_server",
+				"xds:///default/test-xds",
 				testruntime.BuildCaller(
 					testruntime.MethodEcho,
 				),
@@ -230,7 +227,6 @@ func TestReconciller(t *testing.T) {
 				testruntime.BuildXDSService(
 					"test-xds",
 					"default",
-					"echo_server",
 					testruntime.WithRoutes(
 						testruntime.BuildSingleRoute("default"),
 					),
@@ -263,7 +259,7 @@ func TestReconciller(t *testing.T) {
 			},
 			backendsBehavior: answer,
 			doAssert: testruntime.CallN(
-				"xds:///echo_server",
+				"xds:///default/test-xds",
 				testruntime.BuildCaller(
 					testruntime.MethodEcho,
 				),
@@ -290,7 +286,6 @@ func TestReconciller(t *testing.T) {
 				testruntime.BuildXDSService(
 					"test-xds",
 					"default",
-					"echo_server",
 					testruntime.WithRoutes(
 						testruntime.BuildSingleRoute("default"),
 					),
@@ -323,7 +318,7 @@ func TestReconciller(t *testing.T) {
 			},
 			backendsBehavior: answer,
 			doAssert: testruntime.CallOnce(
-				"xds:///echo_server",
+				"xds:///default/test-xds",
 				testruntime.BuildCaller(
 					testruntime.MethodEcho,
 				),
@@ -346,7 +341,6 @@ func TestReconciller(t *testing.T) {
 				testruntime.BuildXDSService(
 					"test-xds",
 					"default",
-					"echo_server",
 					testruntime.WithRoutes(
 						testruntime.BuildRoute(
 							testruntime.WithPathMatcher(
@@ -369,7 +363,7 @@ func TestReconciller(t *testing.T) {
 			backendsBehavior: answer,
 			doAssert: testruntime.MultiAssert(
 				testruntime.CallOnce(
-					"xds:///echo_server",
+					"xds:///default/test-xds",
 					testruntime.BuildCaller(
 						testruntime.MethodEchoPremium,
 					),
@@ -381,7 +375,7 @@ func TestReconciller(t *testing.T) {
 					),
 				),
 				testruntime.CallOnce(
-					"xds:///echo_server",
+					"xds:///default/test-xds",
 					testruntime.BuildCaller(
 						testruntime.MethodEcho,
 					),
@@ -405,7 +399,6 @@ func TestReconciller(t *testing.T) {
 				testruntime.BuildXDSService(
 					"test-xds",
 					"default",
-					"echo_server",
 					testruntime.WithRoutes(
 						testruntime.BuildRoute(
 							testruntime.WithPathMatcher(
@@ -428,7 +421,7 @@ func TestReconciller(t *testing.T) {
 			backendsBehavior: answer,
 			doAssert: testruntime.MultiAssert(
 				testruntime.CallOnce(
-					"xds:///echo_server",
+					"xds:///default/test-xds",
 					testruntime.BuildCaller(
 						testruntime.MethodEchoPremium,
 					),
@@ -440,7 +433,7 @@ func TestReconciller(t *testing.T) {
 					),
 				),
 				testruntime.CallOnce(
-					"xds:///echo_server",
+					"xds:///default/test-xds",
 					testruntime.BuildCaller(
 						testruntime.MethodEcho,
 					),
@@ -464,7 +457,6 @@ func TestReconciller(t *testing.T) {
 				testruntime.BuildXDSService(
 					"test-xds",
 					"default",
-					"echo_server",
 					testruntime.WithRoutes(
 						testruntime.BuildRoute(
 							testruntime.WithPathMatcher(
@@ -491,7 +483,7 @@ func TestReconciller(t *testing.T) {
 			backendsBehavior: answer,
 			doAssert: testruntime.MultiAssert(
 				testruntime.CallOnce(
-					"xds:///echo_server",
+					"xds:///default/test-xds",
 					testruntime.BuildCaller(
 						testruntime.MethodEchoPremium,
 					),
@@ -503,7 +495,7 @@ func TestReconciller(t *testing.T) {
 					),
 				),
 				testruntime.CallOnce(
-					"xds:///echo_server",
+					"xds:///default/test-xds",
 					testruntime.BuildCaller(
 						testruntime.MethodEcho,
 					),
@@ -527,7 +519,6 @@ func TestReconciller(t *testing.T) {
 				testruntime.BuildXDSService(
 					"test-xds",
 					"default",
-					"echo_server",
 					testruntime.WithRoutes(
 						testruntime.BuildRoute(
 							testruntime.WithCaseSensitive(false),
@@ -551,7 +542,7 @@ func TestReconciller(t *testing.T) {
 			backendsBehavior: answer,
 			doAssert: testruntime.MultiAssert(
 				testruntime.CallOnce(
-					"xds:///echo_server",
+					"xds:///default/test-xds",
 					testruntime.BuildCaller(
 						testruntime.MethodEchoPremium,
 					),
@@ -563,7 +554,7 @@ func TestReconciller(t *testing.T) {
 					),
 				),
 				testruntime.CallOnce(
-					"xds:///echo_server",
+					"xds:///default/test-xds",
 					testruntime.BuildCaller(
 						testruntime.MethodEcho,
 					),
@@ -587,7 +578,6 @@ func TestReconciller(t *testing.T) {
 				testruntime.BuildXDSService(
 					"test-xds",
 					"default",
-					"echo_server",
 					testruntime.WithRoutes(
 						testruntime.BuildRoute(
 							testruntime.WithHeaderMatchers(
@@ -613,7 +603,7 @@ func TestReconciller(t *testing.T) {
 			backendsBehavior: answer,
 			doAssert: testruntime.MultiAssert(
 				testruntime.CallOnce(
-					"xds:///echo_server",
+					"xds:///default/test-xds",
 					testruntime.BuildCaller(
 						testruntime.MethodEcho,
 						testruntime.WithMetadata(
@@ -629,7 +619,7 @@ func TestReconciller(t *testing.T) {
 					),
 				),
 				testruntime.CallOnce(
-					"xds:///echo_server",
+					"xds:///default/test-xds",
 					testruntime.BuildCaller(
 						testruntime.MethodEcho,
 						testruntime.WithMetadata(
@@ -656,7 +646,6 @@ func TestReconciller(t *testing.T) {
 				testruntime.BuildXDSService(
 					"test-xds",
 					"default",
-					"echo_server",
 					testruntime.WithRoutes(
 						testruntime.BuildRoute(
 							testruntime.WithHeaderMatchers(
@@ -680,7 +669,7 @@ func TestReconciller(t *testing.T) {
 			backendsBehavior: answer,
 			doAssert: testruntime.MultiAssert(
 				testruntime.CallOnce(
-					"xds:///echo_server",
+					"xds:///default/test-xds",
 					testruntime.BuildCaller(
 						testruntime.MethodEcho,
 						testruntime.WithMetadata(
@@ -698,7 +687,7 @@ func TestReconciller(t *testing.T) {
 					),
 				),
 				testruntime.CallOnce(
-					"xds:///echo_server",
+					"xds:///default/test-xds",
 					testruntime.BuildCaller(
 						testruntime.MethodEcho,
 					),
@@ -722,7 +711,6 @@ func TestReconciller(t *testing.T) {
 				testruntime.BuildXDSService(
 					"test-xds",
 					"default",
-					"echo_server",
 					testruntime.WithRoutes(
 						testruntime.BuildRoute(
 							testruntime.WithHeaderMatchers(
@@ -749,7 +737,7 @@ func TestReconciller(t *testing.T) {
 			backendsBehavior: answer,
 			doAssert: testruntime.MultiAssert(
 				testruntime.CallOnce(
-					"xds:///echo_server",
+					"xds:///default/test-xds",
 					testruntime.BuildCaller(
 						testruntime.MethodEcho,
 						testruntime.WithMetadata(
@@ -766,7 +754,7 @@ func TestReconciller(t *testing.T) {
 					),
 				),
 				testruntime.CallOnce(
-					"xds:///echo_server",
+					"xds:///default/test-xds",
 					testruntime.BuildCaller(
 						testruntime.MethodEcho,
 					),
@@ -790,7 +778,6 @@ func TestReconciller(t *testing.T) {
 				testruntime.BuildXDSService(
 					"test-xds",
 					"default",
-					"echo_server",
 					testruntime.WithRoutes(
 						testruntime.BuildRoute(
 							testruntime.WithHeaderMatchers(
@@ -817,7 +804,7 @@ func TestReconciller(t *testing.T) {
 			backendsBehavior: answer,
 			doAssert: testruntime.MultiAssert(
 				testruntime.CallOnce(
-					"xds:///echo_server",
+					"xds:///default/test-xds",
 					testruntime.BuildCaller(
 						testruntime.MethodEcho,
 						testruntime.WithMetadata(
@@ -834,7 +821,7 @@ func TestReconciller(t *testing.T) {
 					),
 				),
 				testruntime.CallOnce(
-					"xds:///echo_server",
+					"xds:///default/test-xds",
 					testruntime.BuildCaller(
 						testruntime.MethodEcho,
 						testruntime.WithMetadata(
@@ -862,7 +849,6 @@ func TestReconciller(t *testing.T) {
 				testruntime.BuildXDSService(
 					"test-xds",
 					"default",
-					"echo_server",
 					testruntime.WithRoutes(
 						testruntime.BuildRoute(
 							testruntime.WithHeaderMatchers(
@@ -886,7 +872,7 @@ func TestReconciller(t *testing.T) {
 			backendsBehavior: answer,
 			doAssert: testruntime.MultiAssert(
 				testruntime.CallOnce(
-					"xds:///echo_server",
+					"xds:///default/test-xds",
 					testruntime.BuildCaller(
 						testruntime.MethodEcho,
 						testruntime.WithMetadata(
@@ -903,7 +889,7 @@ func TestReconciller(t *testing.T) {
 					),
 				),
 				testruntime.CallOnce(
-					"xds:///echo_server",
+					"xds:///default/test-xds",
 					testruntime.BuildCaller(testruntime.MethodEcho),
 					testruntime.NoCallErrors,
 					testruntime.AggregateByBackendID(
@@ -923,7 +909,6 @@ func TestReconciller(t *testing.T) {
 				testruntime.BuildXDSService(
 					"test-xds",
 					"default",
-					"echo_server",
 					testruntime.WithRoutes(
 						testruntime.BuildRoute(
 							testruntime.WithHeaderMatchers(
@@ -947,7 +932,7 @@ func TestReconciller(t *testing.T) {
 			backendsBehavior: answer,
 			doAssert: testruntime.MultiAssert(
 				testruntime.CallOnce(
-					"xds:///echo_server",
+					"xds:///default/test-xds",
 					testruntime.BuildCaller(
 						testruntime.MethodEcho,
 						testruntime.WithMetadata(
@@ -964,7 +949,7 @@ func TestReconciller(t *testing.T) {
 					),
 				),
 				testruntime.CallOnce(
-					"xds:///echo_server",
+					"xds:///default/test-xds",
 					testruntime.BuildCaller(
 						testruntime.MethodEcho,
 						testruntime.WithMetadata(
@@ -992,7 +977,6 @@ func TestReconciller(t *testing.T) {
 				testruntime.BuildXDSService(
 					"test-xds",
 					"default",
-					"echo_server",
 					testruntime.WithRoutes(
 						testruntime.BuildRoute(
 							testruntime.WithHeaderMatchers(
@@ -1016,7 +1000,7 @@ func TestReconciller(t *testing.T) {
 			backendsBehavior: answer,
 			doAssert: testruntime.MultiAssert(
 				testruntime.CallOnce(
-					"xds:///echo_server",
+					"xds:///default/test-xds",
 					testruntime.BuildCaller(
 						testruntime.MethodEcho,
 						testruntime.WithMetadata(
@@ -1033,7 +1017,7 @@ func TestReconciller(t *testing.T) {
 					),
 				),
 				testruntime.CallOnce(
-					"xds:///echo_server",
+					"xds:///default/test-xds",
 					testruntime.BuildCaller(
 						testruntime.MethodEcho,
 						testruntime.WithMetadata(
@@ -1061,7 +1045,6 @@ func TestReconciller(t *testing.T) {
 				testruntime.BuildXDSService(
 					"test-xds",
 					"default",
-					"echo_server",
 					testruntime.WithRoutes(
 						testruntime.BuildRoute(
 							// 20.00% of the traffic will go to v2.
@@ -1085,7 +1068,7 @@ func TestReconciller(t *testing.T) {
 			},
 			backendsBehavior: answer,
 			doAssert: testruntime.CallN(
-				"xds:///echo_server",
+				"xds:///default/test-xds",
 				testruntime.BuildCaller(
 					testruntime.MethodEcho,
 				),
@@ -1106,7 +1089,6 @@ func TestReconciller(t *testing.T) {
 				testruntime.BuildXDSService(
 					"test-xds",
 					"default",
-					"echo_server",
 					testruntime.WithRoutes(testruntime.BuildSingleRoute("default")),
 					testruntime.WithMaxStreamDuration(50*time.Millisecond),
 					testruntime.WithClusters(
@@ -1130,7 +1112,7 @@ func TestReconciller(t *testing.T) {
 			doAssert: testruntime.WithinDelay(
 				time.Second,
 				testruntime.CallOnce(
-					"xds:///echo_server",
+					"xds:///default/test-xds",
 					testruntime.BuildCaller(
 						testruntime.MethodEcho,
 					),
@@ -1147,7 +1129,6 @@ func TestReconciller(t *testing.T) {
 				testruntime.BuildXDSService(
 					"test-xds",
 					"default",
-					"echo_server",
 					testruntime.WithRoutes(
 						testruntime.BuildRoute(
 							testruntime.WithRouteMaxStreamDuration(50*time.Millisecond),
@@ -1182,7 +1163,7 @@ func TestReconciller(t *testing.T) {
 			doAssert: testruntime.WithinDelay(
 				time.Second,
 				testruntime.CallOnce(
-					"xds:///echo_server",
+					"xds:///default/test-xds",
 					testruntime.BuildCaller(
 						testruntime.MethodEcho,
 					),
@@ -1199,7 +1180,6 @@ func TestReconciller(t *testing.T) {
 				testruntime.BuildXDSService(
 					"test-xds",
 					"default",
-					"echo_server",
 					testruntime.WithRoutes(
 						testruntime.BuildSingleRoute("default"),
 					),
@@ -1223,7 +1203,7 @@ func TestReconciller(t *testing.T) {
 			},
 			backendsBehavior: hang(1 * time.Second),
 			doAssert: testruntime.CallNParallel(
-				"xds:///echo_server",
+				"xds:///default/test-xds",
 				testruntime.BuildCaller(
 					testruntime.MethodEcho,
 				),
@@ -1246,7 +1226,6 @@ func TestReconciller(t *testing.T) {
 				testruntime.BuildXDSService(
 					"test-xds",
 					"default",
-					"echo_server",
 					testruntime.WithRoutes(
 						testruntime.BuildSingleRoute("default"),
 					),
@@ -1284,7 +1263,7 @@ func TestReconciller(t *testing.T) {
 			doAssert: testruntime.ExceedDelay(
 				200*time.Millisecond,
 				testruntime.CallOnce(
-					"xds:///echo_server",
+					"xds:///default/test-xds",
 					testruntime.BuildCaller(
 						testruntime.MethodEcho,
 					),
@@ -1301,7 +1280,6 @@ func TestReconciller(t *testing.T) {
 				testruntime.BuildXDSService(
 					"test-xds",
 					"default",
-					"echo_server",
 					testruntime.WithRoutes(
 						testruntime.BuildSingleRoute("default"),
 					),
@@ -1339,7 +1317,7 @@ func TestReconciller(t *testing.T) {
 			doAssert: testruntime.ExceedDelay(
 				200*time.Millisecond,
 				testruntime.CallOnce(
-					"xds:///echo_server",
+					"xds:///default/test-xds",
 					testruntime.BuildCaller(
 						testruntime.MethodEcho,
 						testruntime.WithMetadata(
@@ -1362,7 +1340,7 @@ func TestReconciller(t *testing.T) {
 				testruntime.BuildXDSService(
 					"test-xds",
 					"default",
-					"echo_server",
+
 					testruntime.WithRoutes(
 						testruntime.BuildSingleRoute("default"),
 					),
@@ -1398,7 +1376,7 @@ func TestReconciller(t *testing.T) {
 			},
 			backendsBehavior: answer,
 			doAssert: testruntime.CallOnce(
-				"xds:///echo_server",
+				"xds:///default/test-xds",
 				testruntime.BuildCaller(
 					testruntime.MethodEcho,
 				),
@@ -1414,7 +1392,6 @@ func TestReconciller(t *testing.T) {
 				testruntime.BuildXDSService(
 					"test-xds",
 					"default",
-					"echo_server",
 					testruntime.WithRoutes(
 						testruntime.BuildSingleRoute("default"),
 					),
@@ -1450,7 +1427,7 @@ func TestReconciller(t *testing.T) {
 			},
 			backendsBehavior: answer,
 			doAssert: testruntime.CallOnce(
-				"xds:///echo_server",
+				"xds:///default/test-xds",
 				testruntime.BuildCaller(
 					testruntime.MethodEcho,
 				),
@@ -1466,7 +1443,6 @@ func TestReconciller(t *testing.T) {
 				testruntime.BuildXDSService(
 					"test-xds",
 					"default",
-					"echo_server",
 					testruntime.WithRoutes(
 						testruntime.BuildSingleRoute("default"),
 					),
@@ -1502,7 +1478,7 @@ func TestReconciller(t *testing.T) {
 			},
 			backendsBehavior: answer,
 			doAssert: testruntime.CallOnce(
-				"xds:///echo_server",
+				"xds:///default/test-xds",
 				testruntime.BuildCaller(
 					testruntime.MethodEcho,
 					testruntime.WithMetadata(

--- a/pkg/testruntime/builder.go
+++ b/pkg/testruntime/builder.go
@@ -200,14 +200,11 @@ func WithMaxStreamDuration(d time.Duration) XDSServiceOpt {
 	}
 }
 
-func BuildXDSService(name, namespace, listener string, opts ...XDSServiceOpt) kxdsv1alpha1.XDSService {
+func BuildXDSService(name, namespace string, opts ...XDSServiceOpt) kxdsv1alpha1.XDSService {
 	s := kxdsv1alpha1.XDSService{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
-		},
-		Spec: kxdsv1alpha1.XDSServiceSpec{
-			Listener: listener,
 		},
 	}
 


### PR DESCRIPTION
### What Does This PR do?

This PR updates the `XDSService` resource to remove the `spec.listerner` field in favor of a `namespace/name` listerner name. 